### PR TITLE
fix(nav): Remove extra close div on all sub-pages

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -121,7 +121,7 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 			<div class="wp-block-navigation__responsive-container  has-text-color has-base-color has-background has-contrast-background-color" style="" id="modal-3" >
 				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
 					<div class="wp-block-navigation__responsive-dialog" aria-label="Menu" >
-						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content"></div>
+						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content">
 							<button aria-label="Close menu" data-micromodal-close class="wp-block-navigation__responsive-container-close" ><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
 							
 <ul class="wp-block-social-links is-layout-flex wp-block-social-links-is-layout-flex"></ul>

--- a/socials/index.html
+++ b/socials/index.html
@@ -121,7 +121,7 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 			<div class="wp-block-navigation__responsive-container  has-text-color has-base-color has-background has-contrast-background-color" style="" id="modal-3" >
 				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
 					<div class="wp-block-navigation__responsive-dialog" aria-label="Menu" >
-						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content"></div>
+						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content">
 							<button aria-label="Close menu" data-micromodal-close class="wp-block-navigation__responsive-container-close" ><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
 							
 <ul class="wp-block-social-links is-layout-flex wp-block-social-links-is-layout-flex"></ul>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -121,7 +121,7 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 			<div class="wp-block-navigation__responsive-container  has-text-color has-base-color has-background has-contrast-background-color" style="" id="modal-3" >
 				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
 					<div class="wp-block-navigation__responsive-dialog" aria-label="Menu" >
-						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content"></div>
+						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content">
 							<button aria-label="Close menu" data-micromodal-close class="wp-block-navigation__responsive-container-close" ><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
 							
 <ul class="wp-block-social-links is-layout-flex wp-block-social-links-is-layout-flex"></ul>

--- a/team/index.html
+++ b/team/index.html
@@ -121,7 +121,7 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 			<div class="wp-block-navigation__responsive-container  has-text-color has-base-color has-background has-contrast-background-color" style="" id="modal-3" >
 				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
 					<div class="wp-block-navigation__responsive-dialog" aria-label="Menu" >
-						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content"></div>
+						<div class="wp-block-navigation__responsive-container-content" id="modal-3-content">
 							<button aria-label="Close menu" data-micromodal-close class="wp-block-navigation__responsive-container-close" ><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
 							
 <ul class="wp-block-social-links is-layout-flex wp-block-social-links-is-layout-flex"></ul>


### PR DESCRIPTION
I caused this bug in the mobile navbar on Monday by missing the fact that VS Code autocompleted the close tag for a div when I cut and pasted it to move it to a new location. This messed up the entire layout of the mobile navbar as shown below.

![image](https://github.com/HoneycombRacing/honeycombracing.github.io/assets/52345992/f516230d-b381-473d-bf18-302ccf669646)

