### PR TITLE
fix(home): Stop sponsor logos being stretched horizontally

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,23 +237,23 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 
 
 <div class="wp-block-group alignfull is-content-justification-center is-layout-flex wp-container-22 wp-block-group-is-layout-flex">
-<figure class="wp-block-image size-large is-resized"><img decoding="async" src="assets/uoe_engineering_2_colour_0.jpg?w=1024" alt="" class="wp-image-25" style="width:200px;height:60px" width="200" height="60"/></figure>
+<figure class="wp-block-image size-large is-resized"><img decoding="async" src="assets/uoe_engineering_2_colour_0.jpg?w=1024" alt="" class="wp-image-25" style="height:60px"/></figure>
 
 
 
-<figure class="wp-block-image size-full is-resized"><img decoding="async" src="assets/muirhall.png" alt="" class="wp-image-21" style="width:200px;height:60px" width="200" height="60"/></figure>
+<figure class="wp-block-image size-full is-resized"><img decoding="async" src="assets/muirhall.png" alt="" class="wp-image-21" style="height:60px"/></figure>
 
 
 
-<figure class="wp-block-image size-large is-resized"><img decoding="async" src="assets/screenshot-2023-08-07-112526.png?w=1024" alt="" class="wp-image-28" style="width:168px;height:50px" width="168" height="50"/></figure>
+<figure class="wp-block-image size-large is-resized"><img decoding="async" src="assets/screenshot-2023-08-07-112526.png?w=1024" alt="" class="wp-image-28" style="height:50px"/></figure>
 
 
 
-<figure class="wp-block-image size-full is-resized"><img decoding="async" src="assets/carter.png" alt="" class="wp-image-26" style="width:200px;height:60px" width="200" height="60"/></figure>
+<figure class="wp-block-image size-full is-resized"><img decoding="async" src="assets/carter.png" alt="" class="wp-image-26" style="height:60px"/></figure>
 
 
 
-<figure class="wp-block-image size-large is-resized"><img decoding="async" src="assets/jdf_2016_jdf-logo_1x1-1.jpg?w=1024" alt="" class="wp-image-27" style="width:200px;height:60px" width="200" height="60"/></figure>
+<figure class="wp-block-image size-large is-resized"><img decoding="async" src="assets/jdf_2016_jdf-logo_1x1-1.jpg?w=1024" alt="" class="wp-image-27" style="height:60px"/></figure>
 </div>
 </div>
 


### PR DESCRIPTION
Not sure why it was like this but I fixed it lol

Before: 
![image](https://github.com/HoneycombRacing/honeycombracing.github.io/assets/52345992/dc48258a-df3f-4c54-a9d0-26bc23b085de)

After:
![image](https://github.com/HoneycombRacing/honeycombracing.github.io/assets/52345992/f76d93d2-e65b-48ca-91d5-eb6d7aebb2de)
